### PR TITLE
 fix build errors by improving LibXml2 build support

### DIFF
--- a/lib/src/CMakeLists.txt
+++ b/lib/src/CMakeLists.txt
@@ -54,12 +54,24 @@ while (TRUE)
             ${LIBXML2_BUILD_CMD}
         INSTALL_COMMAND
             ${LIBXML2_BUILD_CMD} install
+        # BUILD_BYPRODUCTS needed by Ninja
+        BUILD_BYPRODUCTS <INSTALL_DIR>/lib/libxml2_a.lib
     )
 
     set (LIBXML2_FOUND TRUE)
     set (LIBXML2_INCLUDE_DIR "${LIBXML2_INSTALL_DIR}/include/libxml2")
     set (LIBXML2_LIBRARIES "${LIBXML2_INSTALL_DIR}/lib/libxml2_a.lib")
     set (LIBXML2_DEFINITIONS "/DLIBXML_STATIC")
+    file(MAKE_DIRECTORY ${LIBXML2_INCLUDE_DIR})
+
+    add_library(libxml2 STATIC IMPORTED)
+    add_dependencies(libxml2 ${INTERNAL_LIBXML_TGT})
+    set_target_properties(libxml2 PROPERTIES
+        IMPORTED_LOCATION ${LIBXML2_LIBRARIES}
+        IMPORTED_IMPLIB ${LIBXML2_LIBRARIES}
+        INTERFACE_INCLUDE_DIRECTORIES "${LIBXML2_INCLUDE_DIR}"
+    )
+    add_library(LibXml2::LibXml2 ALIAS libxml2)
 
     break()
 endwhile ()
@@ -126,7 +138,8 @@ set (
 )
 
 add_library(${PROJECT_NAME} SHARED ${src})
-target_link_libraries(${PROJECT_NAME} PRIVATE ${LIBXML2_LIBRARIES})
+add_dependencies(${PROJECT_NAME} LibXml2::LibXml2)
+target_link_libraries(${PROJECT_NAME} PRIVATE LibXml2::LibXml2)
 
 if (WIN32)
     target_link_libraries(${PROJECT_NAME} PUBLIC Setupapi.lib Ws2_32.lib imm32.lib winmm.lib)
@@ -135,7 +148,6 @@ endif ()
 set_target_properties(${PROJECT_NAME} PROPERTIES VERSION ${COMMSDSL_VERSION})
 
 target_include_directories(${PROJECT_NAME}
-    PRIVATE ${LIBXML2_INCLUDE_DIR}
     PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/lib/include>
     INTERFACE $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
@@ -188,5 +200,3 @@ install (
     FILES ${CMAKE_BINARY_DIR}/LibCommsdslConfigVersion.cmake
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/LibCommsdsl/cmake/
 )    
-
-

--- a/lib/src/CMakeLists.txt
+++ b/lib/src/CMakeLists.txt
@@ -14,14 +14,12 @@ while (TRUE)
     endif ()
 
     set(LIBXML2_COMPILER)
-    set(LIBXML2_PATHS)
+    set(LIBXML2_PATHS "prefix=install")
     set(LIBXML2_BUILD_COMMAND)
     if (MINGW)
-        set(LIBXML2_PATHS "bindir=install/bin" "incdir=install/include" "libdir=install/lib" "sodir=install/bin")
         set(LIBXML2_COMPILER "compiler=mingw")
         set(LIBXML2_BUILD_CMD make -f Makefile.mingw)
     elseif (MSVC)
-        set(LIBXML2_PATHS "bindir=install\\bin" "incdir=install\\include" "libdir=install\\lib" "sodir=install\\bin")
         set(LIBXML2_COMPILER "compiler=msvc")
         set(LIBXML2_BUILD_CMD nmake /f Makefile.msvc)
     else()
@@ -32,6 +30,7 @@ while (TRUE)
     set (LIBXML2_DIR "${CMAKE_CURRENT_BINARY_DIR}/libxml2")
     set (LIBXML2_SRC_DIR "${LIBXML2_DIR}/src")
     set (LIBXML2_BIN_DIR "${LIBXML2_SRC_DIR}/win32")
+    set (LIBXML2_INSTALL_DIR "${LIBXML2_BIN_DIR}/install")
 
     set (LIBXML2_CRUNTIME)
     if (("${CMAKE_BUILD_TYPE}" STREQUAL "") OR ("${CMAKE_BUILD_TYPE}" STREQUAL "None") OR ("${CMAKE_BUILD_TYPE}" STREQUAL "Debug"))
@@ -50,6 +49,7 @@ while (TRUE)
             cscript ${LIBXML2_BIN_DIR}/configure.js ftp=no html=no iconv=no ${LIBXML2_COMPILER} static=yes ${LIBXML2_CRUNTIME} ${LIBXML2_PATHS}
         SOURCE_DIR "${LIBXML2_SRC_DIR}"
         BINARY_DIR "${LIBXML2_BIN_DIR}"
+        INSTALL_DIR "${LIBXML2_INSTALL_DIR}"
         BUILD_COMMAND
             ${LIBXML2_BUILD_CMD}
         INSTALL_COMMAND
@@ -57,9 +57,10 @@ while (TRUE)
     )
 
     set (LIBXML2_FOUND TRUE)
-    set (LIBXML2_INCLUDE_DIR "${LIBXML2_BIN_DIR}/install/include/libxml2")
-    set (LIBXML2_LIBRARIES "${LIBXML2_BIN_DIR}/install/lib/libxml2_a.lib")
+    set (LIBXML2_INCLUDE_DIR "${LIBXML2_INSTALL_DIR}/include/libxml2")
+    set (LIBXML2_LIBRARIES "${LIBXML2_INSTALL_DIR}/lib/libxml2_a.lib")
     set (LIBXML2_DEFINITIONS "/DLIBXML_STATIC")
+
     break()
 endwhile ()
 
@@ -133,7 +134,7 @@ endif ()
 
 set_target_properties(${PROJECT_NAME} PROPERTIES VERSION ${COMMSDSL_VERSION})
 
-target_include_directories(${PROJECT_NAME} 
+target_include_directories(${PROJECT_NAME}
     PRIVATE ${LIBXML2_INCLUDE_DIR}
     PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/lib/include>
     INTERFACE $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>

--- a/lib/src/CMakeLists.txt
+++ b/lib/src/CMakeLists.txt
@@ -13,8 +13,19 @@ while (TRUE)
         break()
     endif ()
 
-    if (NOT MSVC)
-        message (FATAL_ERROR "At this moment only MSVC compiler is supported for windows builds")
+    set(LIBXML2_COMPILER)
+    set(LIBXML2_PATHS)
+    set(LIBXML2_BUILD_COMMAND)
+    if (MINGW)
+        set(LIBXML2_PATHS "bindir=install/bin" "incdir=install/include" "libdir=install/lib" "sodir=install/bin")
+        set(LIBXML2_COMPILER "compiler=mingw")
+        set(LIBXML2_BUILD_CMD make -f Makefile.mingw)
+    elseif (MSVC)
+        set(LIBXML2_PATHS "bindir=install\\bin" "incdir=install\\include" "libdir=install\\lib" "sodir=install\\bin")
+        set(LIBXML2_COMPILER "compiler=msvc")
+        set(LIBXML2_BUILD_CMD nmake /f Makefile.msvc)
+    else()
+        message (FATAL_ERROR "At this moment only MSVC and MINGW compilers are supported for windows builds")
     endif ()
 
     set (INTERNAL_LIBXML_TGT "libxml2_tgt")
@@ -36,13 +47,13 @@ while (TRUE)
         GIT_TAG "v2.9.7"
         UPDATE_DISCONNECTED 1
         CONFIGURE_COMMAND
-            cscript ${LIBXML2_BIN_DIR}/configure.js ftp=no html=no iconv=no compiler=msvc static=yes ${LIBXML2_CRUNTIME} bindir=install\\bin incdir=install\\include libdir=install\\lib sodir=install\\bin
+            cscript ${LIBXML2_BIN_DIR}/configure.js ftp=no html=no iconv=no ${LIBXML2_COMPILER} static=yes ${LIBXML2_CRUNTIME} ${LIBXML2_PATHS}
         SOURCE_DIR "${LIBXML2_SRC_DIR}"
         BINARY_DIR "${LIBXML2_BIN_DIR}"
         BUILD_COMMAND
-            nmake /f Makefile.msvc
+            ${LIBXML2_BUILD_CMD}
         INSTALL_COMMAND
-            nmake /f Makefile.msvc install
+            ${LIBXML2_BUILD_CMD} install
     )
 
     set (LIBXML2_FOUND TRUE)


### PR DESCRIPTION
Hi,

after trying to use your library, i realize that it didn't support compiling libxml2 on Windows with MinGW (that's what i use while developing a Qt application with Qt Creator).
So i decided to implement it.

Another problem then occured, due to a missing dependency definition on the external target, making commsdl library being compiled before libxml2.
in order to fix that, i created an imported cmake target and added a dependency to it, in order to be as close as what would happen when using "find_package(LibXml2)".

I hope it can help, and be merged for the next release :)
