### PR TITLE
fix dangling references and add gcc13 compability

### DIFF
--- a/app/commsdsl2comms/src/CommsDispatch.cpp
+++ b/app/commsdsl2comms/src/CommsDispatch.cpp
@@ -386,7 +386,7 @@ bool CommsDispatch::commsWritePlatformDispatchInternal() const
         auto platformCheckFunc = 
             [&p](const commsdsl::gen::Message& msg)
             {
-                auto& msgPlatforms = msg.dslObj().platforms();
+                const auto msgPlatforms = msg.dslObj().platforms();
                 if (msgPlatforms.empty()) {
                     return true;
                 }

--- a/app/commsdsl2comms/src/CommsEnumField.cpp
+++ b/app/commsdsl2comms/src/CommsEnumField.cpp
@@ -528,8 +528,8 @@ std::string CommsEnumField::commsCompPrepValueStrImpl(const std::string& accStr,
     }
 
     auto& castedOtherEnum = static_cast<const CommsEnumField&>(*otherEnum);
-    auto& otherValues = castedOtherEnum.enumDslObj().values();
-    auto otherIter = otherValues.find(std::string(value, lastDot + 1));
+    const auto otherValues = castedOtherEnum.enumDslObj().values();
+    const auto otherIter = otherValues.find(std::string(value, lastDot + 1));
     if (otherIter == otherValues.end()) {
         static constexpr bool Should_not_happen = false;
         static_cast<void>(Should_not_happen);

--- a/app/commsdsl2comms/src/CommsInputMessages.cpp
+++ b/app/commsdsl2comms/src/CommsInputMessages.cpp
@@ -230,7 +230,7 @@ bool CommsInputMessages::commsWritePlatformInputMessagesInternal() const
         auto platformCheckFunc = 
             [&p](const commsdsl::gen::Message& msg)
             {
-                auto& msgPlatforms = msg.dslObj().platforms();
+                const auto msgPlatforms = msg.dslObj().platforms();
                 if (msgPlatforms.empty()) {
                     return true;
                 }

--- a/app/commsdsl2comms/src/CommsIntField.cpp
+++ b/app/commsdsl2comms/src/CommsIntField.cpp
@@ -421,8 +421,8 @@ std::string CommsIntField::commsCompPrepValueStrImpl(const std::string& accStr, 
         // nothing to do
     }
 
-    auto& specials = intDslObj().specialValues();
-    auto iter = specials.find(value);
+    const auto specials = intDslObj().specialValues();
+    const auto iter = specials.find(value);
     if (iter != specials.end()) {
         return valToString(iter->second.m_value);
     }

--- a/app/commsdsl2comms/src/CommsMsgFactory.cpp
+++ b/app/commsdsl2comms/src/CommsMsgFactory.cpp
@@ -484,7 +484,7 @@ bool CommsMsgFactory::commsWritePlatformMsgFactoryInternal() const
         auto platformCheckFunc = 
             [&p](const commsdsl::gen::Message& msg)
             {
-                auto& msgPlatforms = msg.dslObj().platforms();
+                const auto msgPlatforms = msg.dslObj().platforms();
                 if (msgPlatforms.empty()) {
                     return true;
                 }

--- a/app/commsdsl2comms/src/CommsSetField.cpp
+++ b/app/commsdsl2comms/src/CommsSetField.cpp
@@ -404,8 +404,8 @@ std::string CommsSetField::commsValueAccessStrImpl(const std::string& accStr, co
         return CommsBase::commsValueAccessStrImpl(accStr, prefix);
     }
 
-    auto& bits = setDslObj().bits();
-    auto iter = bits.find(accStr);
+    const auto bits = setDslObj().bits();
+    const auto iter = bits.find(accStr);
     if (iter == bits.end()) {
         generator().logger().error("Failed to find bit reference " + accStr + " for field " + comms::scopeFor(*this, generator()));
         assert(false);
@@ -417,7 +417,7 @@ std::string CommsSetField::commsValueAccessStrImpl(const std::string& accStr, co
 
 bool CommsSetField::commsVerifyInnerRefImpl(const std::string& refStr) const
 {
-    auto& bits = setDslObj().bits();
+    const auto bits = setDslObj().bits();
     return bits.find(refStr) != bits.end();
 }
 

--- a/lib/include/commsdsl/parse/DataField.h
+++ b/lib/include/commsdsl/parse/DataField.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include <vector>
+#include <cstdint>
 
 #include "Field.h"
 


### PR DESCRIPTION
`enumDslObj()` and `dslObj()` returns a new object, which goes out of scope after the assignment. Therefore there are dangling references after the assignments.


the cstdint is required for gcc13